### PR TITLE
add support for default flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,12 +25,16 @@ const removeOptionsFromArgs = require('./utils/removeOptionsFromArgs');
 const createMultiIndex = require('./utils/createMultiIndex');
 const logComponentTree = require('./utils/logComponentTree');
 const validateArguments = require('./utils/validateArguments');
+const getDefaultConfig = require('./utils/getDefaultConfig');
 
 // Root directory
 const ROOT_DIR = process.cwd();
 
 // Grab provided args
 let [, , ...args] = process.argv;
+
+// Get the default config
+const { config } = getDefaultConfig();
 
 // Set command line interface options for cli
 program
@@ -46,6 +50,7 @@ program
   .option('-s, --scss', 'Adds .scss file to component')
   .option('-p, --proptypes', 'Adds prop-types to component')
   .option('-u, --uppercase', 'Component files start on uppercase letter')
+  .option('-d, --default', 'Uses a default configuration if available')
   .parse(process.argv);
 
 // Remove Node process args options
@@ -60,21 +65,21 @@ args = removeOptionsFromArgs(args);
  */
 function createFiles(componentName, componentPath, cssFileExt) {
   return new Promise((resolve) => {
-    const isTypeScript = program.typescript;
-    const isNative = program.reactnative;
+    const isTypeScript = program.typescript || (program.default && config.includes('typescript'));
+    const isNative = program.reactnative || (program.default && config.includes('reactnative'));
     // File extension
     const ext = isTypeScript ? 'tsx' : 'js';
     const jsxExt = 'jsx';
     const indexFile = `index.${ext}`;
     let name = componentName;
-    const isJsxFile = program.jsx || false;
+    const isJsxFile = program.jsx || (program.default && config.includes('jsx')) || false;
     const componentFileName = `${name}.${isJsxFile ? jsxExt : ext}`;
     // file names to create
     const files = [indexFile, componentFileName];
     // Prettier options property
     const prettierParser = isTypeScript ? 'typescript' : 'babylon';
 
-    if (!program.notest) {
+    if (!program.notest && !(program.default && config.includes('notest'))) {
       files.push(`${name}.test.${ext}`);
     }
 
@@ -83,7 +88,7 @@ function createFiles(componentName, componentPath, cssFileExt) {
       files.push(`${name}.${cssFileExt}`);
     }
 
-    if (program.uppercase) {
+    if (program.uppercase || (program.default && config.includes('uppercase'))) {
       name = stringHelper.capitalizeFirstLetter(name);
 
       for (let i = 0; i < files.length; i += 1) {
@@ -106,21 +111,21 @@ function createFiles(componentName, componentPath, cssFileExt) {
           let data = '';
 
           if (file === indexFile) {
-            data = createIndex(name, program.uppercase);
+            data = createIndex(name, program.uppercase || (program.default && config.includes('uppercase')));
             promises.push(fs.writeFileAsync(
               filePath,
               isTypeScript ? data : formatPrettier(data, prettierParser),
             ));
           } else if (file === `${name}.${ext}` || file === `${name}.${jsxExt}`) {
-            if (program.functional) {
-              data = program.proptypes
+            if (program.functional || (program.default && config.includes('functional'))) {
+              data = program.proptypes || (program.default && config.includes('proptypes'))
                 ? createReactFunctionalComponentWithProps(name)
                 : createReactFunctionalComponent(name);
             } else if (isTypeScript) {
               data = isNative
                 ? createTypeScriptReactNativeComponent(name)
                 : createTypeScriptReactComponent(name);
-            } else if (program.proptypes) {
+            } else if (program.proptypes || (program.default && config.includes('proptypes'))) {
               data = isNative
                 ? createReactNativeComponentWithProps(name)
                 : createReactComponentWithProps(name);
@@ -133,9 +138,9 @@ function createFiles(componentName, componentPath, cssFileExt) {
               isTypeScript ? data : formatPrettier(data, prettierParser),
             ));
           } else if (file.indexOf(`.test.${ext}`) > -1) {
-            data = createTest(name, program.uppercase, isTypeScript);
+            data = createTest(name, program.uppercase || (program.default && config.includes('uppercase')), isTypeScript);
 
-            if (!program.notest) {
+            if (!program.notest && !(program.default && config.includes('notest'))) {
               promises.push(fs.writeFileAsync(
                 filePath,
                 isTypeScript ? data : formatPrettier(data, prettierParser),
@@ -189,15 +194,15 @@ function initialize() {
 
       let cssFileExt = 'css';
 
-      if (program.less) {
+      if (program.less || (program.default && config.includes('less'))) {
         cssFileExt = 'less';
       }
 
-      if (program.scss) {
+      if (program.scss || (program.default && config.includes('scss'))) {
         cssFileExt = 'scss';
       }
 
-      if (program.nocss) {
+      if (program.nocss || (program.default && config.includes('nocss'))) {
         cssFileExt = null;
       }
 

--- a/lib/utils/getDefaultConfig.js
+++ b/lib/utils/getDefaultConfig.js
@@ -1,0 +1,13 @@
+const cosmiconfig = require('cosmiconfig');
+
+const explorer = cosmiconfig('crcf');
+
+/**
+* Fetches saved configs
+* @param {Boolean}
+*/
+function getDefaultConfig() {
+ return explorer.searchSync();
+}
+
+module.exports = getDefaultConfig;

--- a/lib/utils/getDefaultConfig.js
+++ b/lib/utils/getDefaultConfig.js
@@ -4,7 +4,7 @@ const explorer = cosmiconfig('crcf');
 
 /**
 * Fetches saved configs
-* @param {Boolean}
+* @return {Object}
 */
 function getDefaultConfig() {
  return explorer.searchSync();

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "commander": "^2.13.0",
+    "cosmiconfig": "^5.0.5",
     "fs": "0.0.1-security",
     "log-update": "^2.3.0",
     "mkdirp": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,6 +425,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
 cross-spawn@5.1.0, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -565,6 +573,12 @@ encoding@^0.1.11:
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -1214,6 +1228,10 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -1315,6 +1333,13 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.9.1:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -1325,6 +1350,10 @@ js-yaml@^3.9.1:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-parse-helpfulerror@^1.0.2:
   version "1.0.3"
@@ -1823,6 +1852,13 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse-passwd@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is a first go at adding support for some sort of default configuration.

This will allow users to create a configuration array either in the package.json or as an rc file, which looks like this:

```
crcf: [
  "typescript"
]
```

Then any new commands with the `-default` flag will automatically include any options in the array, along with any added options provided.

For example, with the above configuration the command `npx crcf src/component/FooComponent --default` will create tsx files. You can combine this with other flags too, i.e. `npx crcf src/component/FooComponent -dufs`