### PR TITLE
Removed 'Add Story file to component' duplicated CLI option line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,6 @@ program
   .option('-u, --uppercase', 'Component files start on uppercase letter')
   .option('-d, --default', 'Uses a default configuration if available')
   .option('-sb, --stories', 'Add Story file to component')
-  .option('-sb, --stories', 'Add Story file to component')
   .option('-ns, --nosemi', 'No semicolons')
   .parse(process.argv);
 


### PR DESCRIPTION
Hi! I noticed there's a duplicated 'Add Story file to component' option line in the command line interface options. This PR removes it 🙂  

Thanks for the great library! Saved me long, frustrating minutes of creating component files :) 