### PR TITLE
Feature, adds flag `singlequote` to modify prettier formatting on new…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ So now all you have to do is type **npx crcf componentName** and you will get al
   "proptypes",
   "stories",
   "nosemi",
+  "singlequote",
   "cssmodules"
   "namedexports",
   "graphql",
@@ -213,6 +214,7 @@ $ npx crcf create --help
     -h, --help          output usage information
     -sb, --stories      Add Storie file to component
     -ns, --nosemi       No semicolons
+    -sq, --singlequote  Formats output files with single quotes
     -x, --namedexports  Creates files using named exports
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,11 @@ function createFiles(componentName, componentPath, cssFileExt) {
       prettierOptions = { semi: false };
     }
 
+    // Set single quote option
+    if (config.hasFlag('singlequote')) {
+      prettierOptions = { singleQuote: true };
+    }
+
     // Add test
     if (!config.hasFlag('notest')) {
       if (config.hasFlag('spec')) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -110,6 +110,12 @@ const getOptions = () => [
     defaultValue: config.hasFlag('nosemi'),
   },
   {
+    name: 'singlequote',
+    flags: '-sq, --singlequote',
+    description: 'Formats output files with single quotes',
+    defaultValue: config.hasFlag('singlequote'),
+  },
+  {
     name: 'output',
     flags: '-o, --output <directory>',
     description: 'The root directory to create components in',

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -13,7 +13,6 @@ function formatPrettier(str, parser = 'babel', optionsOverride) {
     printWidth: 100,
     semi: true,
     trailingComma: 'es5',
-    singleQuote: true,
     parser,
   };
   const opt = { ...prettierOptions, ...optionsOverride };


### PR DESCRIPTION
This feature would allow specifying if single or double quotes should be used by Prettier when creating new component files, in a fashion similar to [the default behavior in Prettier](https://prettier.io/docs/en/rationale.html#strings).

The feature can be enabled with the following configuration flag:

```
crcf: [
  "singlequote"
]
```

...or the runtime arguments `-sq` or `--singlequote`. This adds `singleQuote: true` to `prettierOptions`.

This is one of my first PRs, so please let me know if you have any feedback! 🙂