### PR TITLE
use prettier options in createMultiIndex fn Fixes #54

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,28 @@ if (cli.output) {
 }
 
 /**
+ * Creates prettier override object
+ * 
+ * @returns {Object} - Prettier overrides
+ */
+const getPrettierOptions = () => {
+   // Prettier parser options
+   let prettierOptions = {};
+
+   // Set no semicolon options
+   if (config.hasFlag('nosemi')) {
+     prettierOptions.semi = false;
+   }
+
+   // Set single quote option
+   if (config.hasFlag('singlequote')) {
+     prettierOptions.singleQuote = true;
+   }
+
+   return prettierOptions;
+};
+
+/**
  * Creates files for component
  *
  * @param {String} componentName - Component name
@@ -76,18 +98,9 @@ function createFiles(componentName, componentPath, cssFileExt) {
     const files = [indexFile, componentFileName];
     // Prettier options property
     const prettierParser = config.hasFlag('typescript') ? 'typescript' : 'babel';
-    // Prettier parser options
-    let prettierOptions = null;
 
-    // Set no semicolon options
-    if (config.hasFlag('nosemi')) {
-      prettierOptions = { semi: false };
-    }
-
-    // Set single quote option
-    if (config.hasFlag('singlequote')) {
-      prettierOptions = { singleQuote: true };
-    }
+    // Prettier overrides
+    const prettierOptions = getPrettierOptions();
 
     // Add test
     if (!config.hasFlag('notest')) {
@@ -203,7 +216,7 @@ function initialize() {
   const folderPath = getComponentParentFolder(componentPath);
 
   if (program.createindex === true) {
-    createMultiIndex(componentPath);
+    createMultiIndex(componentPath, getPrettierOptions());
     return;
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ if (cli.output) {
  */
 const getPrettierOptions = () => {
    // Prettier parser options
-   let prettierOptions = {};
+   const prettierOptions = {};
 
    // Set no semicolon options
    if (config.hasFlag('nosemi')) {

--- a/lib/utils/createMultiIndex.js
+++ b/lib/utils/createMultiIndex.js
@@ -14,8 +14,9 @@ const isLetter = require('./isLetter');
  * - import { Component1, Component2 } from './components'
  *
  * @param {String} folderPath  - Path to folder path
+ * @param {Object} prettierOptions - Prettier options override
  */
-function createMultiIndex(folderPath) {
+function createMultiIndex(folderPath, prettierOptions) {
   fs.readDirAsync(folderPath)
     .then((folders) => removeNoneDir(folderPath, folders)) // Filter out none folders
     .then((folders) => {
@@ -25,7 +26,7 @@ function createMultiIndex(folderPath) {
       const data = createIndexForFolders(filteredFolders);
       const indexFilePath = path.join(folderPath, 'index.js');
 
-      fs.writeFileAsync(indexFilePath, formatPrettier(data, null))
+      fs.writeFileAsync(indexFilePath, formatPrettier(data, null, prettierOptions))
         .then(() => {
           logger.log();
           logger.animateStop();


### PR DESCRIPTION
- adds `getPrettierOptions` fn
- passes user defined prettier overrides to `createMultiIndex` fn